### PR TITLE
added duration to camera control stick commands osd

### DIFF
--- a/src/main/drivers/camera_control.h
+++ b/src/main/drivers/camera_control.h
@@ -49,4 +49,4 @@ PG_DECLARE(cameraControlConfig_t, cameraControlConfig);
 void cameraControlInit();
 
 void cameraControlProcess(uint32_t currentTimeUs);
-void cameraControlKeyPress(cameraControlKey_e key);
+void cameraControlKeyPress(cameraControlKey_e key, uint32_t holdDurationMs);

--- a/src/main/fc/fc_msp.c
+++ b/src/main/fc/fc_msp.c
@@ -1752,7 +1752,7 @@ static mspResult_e mspFcProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
     case MSP_CAMERA_CONTROL:
         {
             const uint8_t key = sbufReadU8(src);
-            cameraControlKeyPress(key);
+            cameraControlKeyPress(key, 0);
         }
         break;
 #endif

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -320,6 +320,8 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
         cameraControlKeyPress(CAMERA_CONTROL_KEY_RIGHT, 0);
     } else if (rcSticks == THR_CE + YAW_CE + PIT_LO + ROL_CE) {
         cameraControlKeyPress(CAMERA_CONTROL_KEY_DOWN, 0);
+    } else if (rcSticks == THR_LO + YAW_CE + PIT_HI + ROL_CE) {
+        cameraControlKeyPress(CAMERA_CONTROL_KEY_UP, 2000);
     }
 #endif
 }

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -311,15 +311,15 @@ void processRcStickPositions(throttleStatus_e throttleStatus)
 
 #ifdef CAMERA_CONTROL
     if (rcSticks == THR_LO + YAW_CE + PIT_LO + ROL_CE) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_ENTER);
+        cameraControlKeyPress(CAMERA_CONTROL_KEY_ENTER, 0);
     } else if (rcSticks == THR_CE + YAW_CE + PIT_CE + ROL_LO) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_LEFT);
+        cameraControlKeyPress(CAMERA_CONTROL_KEY_LEFT, 0);
     } else if (rcSticks == THR_CE + YAW_CE + PIT_HI + ROL_CE) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_UP);
+        cameraControlKeyPress(CAMERA_CONTROL_KEY_UP, 0);
     } else if (rcSticks == THR_CE + YAW_CE + PIT_CE + ROL_HI) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_RIGHT);
+        cameraControlKeyPress(CAMERA_CONTROL_KEY_RIGHT, 0);
     } else if (rcSticks == THR_CE + YAW_CE + PIT_LO + ROL_CE) {
-        cameraControlKeyPress(CAMERA_CONTROL_KEY_DOWN);
+        cameraControlKeyPress(CAMERA_CONTROL_KEY_DOWN, 0);
     }
 #endif
 }


### PR DESCRIPTION
I wanted to use this to also control the secondary OSD on the Runcam Swift 2.
You do this by holding the UP button for 2 seconds.

I added a durationUs argument to cameraControlKeyPress, and added a stick command for it (throttle low, pitch high)