### PR TITLE
camera-control: fix crash on unassigned resource

### DIFF
--- a/src/main/drivers/camera_control.c
+++ b/src/main/drivers/camera_control.c
@@ -161,6 +161,9 @@ static float calculatePWMDutyCycle(const cameraControlKey_e key)
 
 void cameraControlKeyPress(cameraControlKey_e key)
 {
+    if (cameraControlConfig()->ioTag == IO_TAG_NONE || cameraControlPwm.io == IO_NONE)
+        return;
+
     if (key >= CAMERA_CONTROL_KEYS_COUNT)
         return;
 


### PR DESCRIPTION
This fixes the crashing/freezing problems I had when CAMERA_CONTROL resource was IO_NONE
It was an unchecked NULL pointer being de-referenced like @mikeller had suggested.
The check was being done in cameraControlInit but not for cameraControlKeyPress 